### PR TITLE
Created models for section and meeting

### DIFF
--- a/autoscheduler/scraper/models/section.py
+++ b/autoscheduler/scraper/models/section.py
@@ -1,9 +1,42 @@
+"""Models for meetings and sections.
+Together, they represent all the information for a particular meeting time.
+"""
+
+from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
-class Meeting(models.Model):
-    """ Describe model here """
-
 class Section(models.Model):
-    """ Section will contain Meeting objects,
-        which is why its placed below it
+    """ Section contains data for a group of meetings.
     """
+    id = models.IntegerField(primary_key=True) # id is primary key in scraped data
+    subject = models.CharField(max_length=4, db_index=True)
+    course_num = models.IntegerField(db_index=True)
+    section_num = models.IntegerField(db_index=True)
+    term_code = models.IntegerField(db_index=True)
+    min_credits = models.IntegerField()
+    max_credits = models.IntegerField(null=True) #min_credits is never null, but max_credits can be
+    max_enrollment = models.IntegerField()
+    current_enrollment = models.IntegerField()
+    instructor = models.IntegerField()
+
+    class Meta:
+        db_table = "sections"
+
+class Meeting(models.Model):
+    """Describes a particular meeting time of a section.
+    Each section has one or more meetings.
+    """
+    id = models.IntegerField(primary_key=True) # id is primary key in scraped data
+    crn = models.IntegerField(db_index=True) # We'll probably going to be searching for CRNs a lot
+    building = models.CharField(max_length=4, null=True) # Online/research meetings have no building
+    meeting_days = ArrayField(
+        models.BooleanField(),
+        size=7
+    )
+    start_time = models.TimeField(null=True)
+    end_time = models.TimeField(null=True)
+    meeting_type = models.CharField(max_length=3) #Meeting types: LEC, LAB, RES, INS
+    section = models.ForeignKey(Section, on_delete=models.CASCADE)
+
+    class Meta:
+        db_table = "meetings"

--- a/autoscheduler/scraper/models/section.py
+++ b/autoscheduler/scraper/models/section.py
@@ -7,15 +7,14 @@ from django.db import models
 from scraper.models import Instructor
 
 class Section(models.Model):
-    """ Section contains data for a group of meetings.
-    """
-    id = models.IntegerField(primary_key=True) # id is primary key in scraped data
+    """ Section contains data for a group of meetings. """
+    id = models.BigIntegerField(primary_key=True) # id is primary key in scraped data
     subject = models.CharField(max_length=4, db_index=True)
     course_num = models.IntegerField(db_index=True)
     section_num = models.IntegerField(db_index=True)
     term_code = models.IntegerField(db_index=True)
     min_credits = models.IntegerField()
-    max_credits = models.IntegerField(null=True) #min_credits is never null, but max_credits can be
+    max_credits = models.IntegerField(null=True) # min_credits is never null, but max_credits can be
     max_enrollment = models.IntegerField()
     current_enrollment = models.IntegerField()
     instructor = models.ForeignKey(Instructor, on_delete=models.CASCADE)
@@ -27,16 +26,13 @@ class Meeting(models.Model):
     """Describes a particular meeting time of a section.
     Each section has one or more meetings.
     """
-    id = models.IntegerField(primary_key=True) # id is primary key in scraped data
+    id = models.BigIntegerField(primary_key=True) # id is primary key in scraped data
     crn = models.IntegerField(db_index=True) # We'll probably going to be searching for CRNs a lot
     building = models.CharField(max_length=4, null=True) # Online/research meetings have no building
-    meeting_days = ArrayField(
-        models.BooleanField(),
-        size=7
-    )
+    meeting_days = ArrayField(models.BooleanField(), size=7)
     start_time = models.TimeField(null=True)
     end_time = models.TimeField(null=True)
-    meeting_type = models.CharField(max_length=3) #Meeting types: LEC, LAB, RES, INS
+    meeting_type = models.CharField(max_length=3) # Meeting types: LEC, LAB, RES, INS
     section = models.ForeignKey(Section, on_delete=models.CASCADE)
 
     class Meta:

--- a/autoscheduler/scraper/models/section.py
+++ b/autoscheduler/scraper/models/section.py
@@ -4,6 +4,7 @@ Together, they represent all the information for a particular meeting time.
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
+from scraper.models import Instructor
 
 class Section(models.Model):
     """ Section contains data for a group of meetings.
@@ -17,7 +18,7 @@ class Section(models.Model):
     max_credits = models.IntegerField(null=True) #min_credits is never null, but max_credits can be
     max_enrollment = models.IntegerField()
     current_enrollment = models.IntegerField()
-    instructor = models.IntegerField()
+    instructor = models.ForeignKey(Instructor, on_delete=models.CASCADE)
 
     class Meta:
         db_table = "sections"


### PR DESCRIPTION
Closes #25.
This is generally what the meeting and section models should look like, but there are a couple things we should think about together:
- A lot of fields are IntegerFields (IDs, course & section numbers, etc.), but everything is stored in the data is a string. For some of these, I feel like storing them as IntegerFields will be beneficial (eg. sorting by course_num and section_num), but others (like IDs) are debatable.
- Delete behavior for section: Right now, on_delete is set to CASCADE for the section field in a Meeting, meaning if the section if belongs to is deleted, the meeting will as well. I feel like this is the correct behavior.
- ArrayFields: These seem like the easiest way to store meeting days, but can only be used with PostgreSQL. This shouldn't be a problem, but before finalizing this, I want everyone to be aware.
- There is a one-to-many relationship between sections and meetings, so I made section a foreign key for a meeting. I believe this is the best way to do this, since this is the practice Django recommends for one-to-many relationships. If anyone has a different idea, let me know.
- The same applies for the relationship between instructors and sections