### PR TITLE
Fixed instructor table property

### DIFF
--- a/autoscheduler/scraper/models/instructor.py
+++ b/autoscheduler/scraper/models/instructor.py
@@ -7,4 +7,4 @@ class Instructor(models.Model):
     name = models.CharField(max_length=64)
 
     class Meta:
-        db_name = "instructors"
+        db_table = "instructors"


### PR DESCRIPTION
Instructor's Meta class table property was `db_name`, but should have been `db_table`. 