### PR TITLE
Fixed types to correctly declare class members

### DIFF
--- a/autoscheduler/frontend/src/types/Course.ts
+++ b/autoscheduler/frontend/src/types/Course.ts
@@ -1,4 +1,11 @@
 export default class Course {
+  id: string;
+  subject: string;
+  courseNum: number;
+  title: string;
+  description: string | null;
+  creditHours: number | null;
+
   constructor(src: {
       id: string;
       subject: string;

--- a/autoscheduler/frontend/src/types/Department.ts
+++ b/autoscheduler/frontend/src/types/Department.ts
@@ -1,4 +1,8 @@
 export default class Department {
+  id: string;
+  code: string;
+  description: string;
+
   constructor(src: {
       id: string;
       code: string;

--- a/autoscheduler/frontend/src/types/Instructor.ts
+++ b/autoscheduler/frontend/src/types/Instructor.ts
@@ -1,4 +1,7 @@
 export default class Instructor {
+  id: number;
+  name: string;
+
   constructor(src: {
       id: number;
       name: string;

--- a/autoscheduler/frontend/src/types/Meeting.ts
+++ b/autoscheduler/frontend/src/types/Meeting.ts
@@ -1,10 +1,21 @@
 import Section from './Section';
 
 export enum MeetingType {
-    LEC, LAB, RES, INS, EXAM, SEM, PRAC, REC, CLD, CMP, PRL, CLAS, INT
-  }
+  LEC, LAB, RES, INS, EXAM, SEM, PRAC, REC, CLD, CMP, PRL, CLAS, INT
+}
 
 export default class Meeting {
+  id: number;
+  crn: number;
+  building: string | null;
+  meetingDays: boolean[];
+  startTimeHours: number;
+  startTimeMinutes: number;
+  endTimeHours: number;
+  endTimeMinutes: number;
+  meetingType: MeetingType;
+  section: Section;
+
   constructor(src: {
       id: number;
       crn: number;

--- a/autoscheduler/frontend/src/types/Section.ts
+++ b/autoscheduler/frontend/src/types/Section.ts
@@ -1,6 +1,15 @@
 import Instructor from './Instructor';
 
 export default class Section {
+  id: number;
+  subject: string;
+  courseNum: number;
+  sectionNum: number;
+  minCredits: number;
+  maxCredits: number | null;
+  currentEnrollment: number;
+  instructor: Instructor;
+
   constructor(src: {
       id: number;
       subject: string;


### PR DESCRIPTION
Currently, each of the classes we made for types call `Object.assign()` in the constructor to assign class members. However, when I was working on MeetingCard, I realized that this doesn't actually add it to the properties typescript gives to its class. Declaring all members up-front fixes this.