### PR TITLE
Split actions workflow into separate front/backend parts

### DIFF
--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -23,4 +23,4 @@ jobs:
         uses: cclauss/GitHub-Action-for-pylint@master
         with:
         # Installs Django and pylint-django, then runs pylint on all of the files in autoscheduler/
-          args: pip install -r .github/lint-requirements.txt ; pylint autoscheduler/**/*.py --load-plugins pylint_django
+          args: pip install -r .github/lint-requirements.txt ; pylint autoscheduler/** --load-plugins pylint_django

--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -1,0 +1,26 @@
+name: Backend CI
+on: 
+  push:
+    branches-ignore:
+      - 'frontend/**' # Don't run on any frontend branches
+
+jobs:
+  test-backend:
+    name: 'Testing'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: docker-build
+      # This option makes the Postgres container exit when the autoscheduler container does
+        run: docker-compose up --abort-on-container-exit
+
+  lint-backend:
+    name: 'Linting'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: pylint
+        uses: cclauss/GitHub-Action-for-pylint@master
+        with:
+        # Installs Django and pylint-django, then runs pylint on all of the files in autoscheduler/
+          args: pip install -r .github/lint-requirements.txt ; pylint autoscheduler/**/*.py --load-plugins pylint_django

--- a/.github/workflows/frontend-workflow.yml
+++ b/.github/workflows/frontend-workflow.yml
@@ -1,29 +1,12 @@
-name: Continuous-Integration
-on: [push] # This workflow triggers anytime a commit is pushed
+name: Frontend CI
+on:
+  push:
+    branches-ignore:
+      - 'backend/**' # Don't run on any backend branches
 
 jobs:
-  test-backend:
-    name: 'Backend Testing'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: docker-build
-      # This option makes the Postgres container exit when the autoscheduler container does
-        run: docker-compose up --abort-on-container-exit
-
-  lint-backend:
-    name: 'Backend Linting'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: pylint
-        uses: cclauss/GitHub-Action-for-pylint@master
-        with:
-        # Installs Django and pylint-django, then runs pylint on all of the files in autoscheduler/
-          args: pip install -r .github/lint-requirements.txt ; pylint autoscheduler/**/*.py --load-plugins pylint_django
-
   test-frontend:
-    name: 'Frontend Testing'
+    name: 'Testing'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -39,7 +22,7 @@ jobs:
         working-directory: ./autoscheduler/frontend/src
 
   build-frontend:
-    name: 'Frontend Build'
+    name: 'Building'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -56,7 +39,7 @@ jobs:
         working-directory: ./autoscheduler/frontend/src
 
   lint-frontend:
-    name: 'Frontend Linting'
+    name: 'Linting'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
There's really no need for the frontend steps to be checked on the backend branches and vice-versa. As such, this splits up the action into separate parts, which will only be run on their respective branches on push. 

This way, we won't have failing jobs on  branches that are caused by problems in the backend, such as the Django files failing pylint.

Also, I won't be merging these changes into `frontend/master` and `backend/master` until I also make a PR for Danger, which I'll make after this gets merged.