### PR TITLE
Landing Page Fixes

### DIFF
--- a/autoscheduler/frontend/src/components/LandingPage/HelpText.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/HelpText.tsx
@@ -21,25 +21,25 @@ const HelpText: React.SFC = function App() {
             Guidelines
           </Box>
         </Typography>
-        <Typography
-          variant="body1"
-          align="center"
-        >
-          <Box padding={2}>
-          Somebody once told me the world is gonna roll me
-          I ain&apos;t the sharpest tool in the shed
-          She was looking kind of dumb with her finger and her thumb
-          In the shape of an &quot;L&quot; on her forehead
-          Well the years start coming and they don&apos;t stop coming
-          Fed to the rules and I hit the ground running
-          Somebody once told me the world is gonna roll me
-          I ain&apos;t the sharpest tool in the shed
-          She was looking kind of dumb with her finger and her thumb
-          In the shape of an &quot;L&quot; on her forehead
-          Well the years start coming and they don&apos;t stop coming
-          Fed to the rules and I hit the ground running
-          </Box>
-        </Typography>
+        <Box padding={2}>
+          <Typography
+            variant="body1"
+            align="center"
+          >
+            Somebody once told me the world is gonna roll me
+            I ain&apos;t the sharpest tool in the shed
+            She was looking kind of dumb with her finger and her thumb
+            In the shape of an &quot;L&quot; on her forehead
+            Well the years start coming and they don&apos;t stop coming
+            Fed to the rules and I hit the ground running
+            Somebody once told me the world is gonna roll me
+            I ain&apos;t the sharpest tool in the shed
+            She was looking kind of dumb with her finger and her thumb
+            In the shape of an &quot;L&quot; on her forehead
+            Well the years start coming and they don&apos;t stop coming
+            Fed to the rules and I hit the ground running
+          </Typography>
+        </Box>
       </Paper>
     </Grid>
   );

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm.tsx
@@ -25,7 +25,7 @@ const SelectTerm: React.SFC = function App() {
   };
 
   const handleClose = (option: string): void => {
-    // setAnchorEl(null);
+    setAnchorEl(null);
     selectTerm(option);
   };
 

--- a/autoscheduler/frontend/src/components/LandingPage/SelectTerm.tsx
+++ b/autoscheduler/frontend/src/components/LandingPage/SelectTerm.tsx
@@ -18,13 +18,15 @@ const ITEM_HEIGHT = 48;
 const SelectTerm: React.SFC = function App() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
+  const [selectedTerm, selectTerm] = React.useState(options[0]);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleClose = (): void => {
-    setAnchorEl(null);
+  const handleClose = (option: string): void => {
+    // setAnchorEl(null);
+    selectTerm(option);
   };
 
   return (
@@ -50,7 +52,7 @@ const SelectTerm: React.SFC = function App() {
           id="long-menu"
           anchorEl={anchorEl}
           anchorOrigin={{
-            vertical: 'bottom',
+            vertical: 'top',
             horizontal: 'center',
           }}
           transformOrigin={{
@@ -72,8 +74,8 @@ const SelectTerm: React.SFC = function App() {
           {options.map((option) => (
             <MenuItem
               key={option}
-              selected={option === 'Pyxis'}
-              onClick={handleClose}
+              selected={option === selectedTerm}
+              onClick={(): void => handleClose(option)}
             >
               {option}
             </MenuItem>

--- a/autoscheduler/frontend/src/components/NavBar.tsx
+++ b/autoscheduler/frontend/src/components/NavBar.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import {
   AppBar, Toolbar, Typography, Button, IconButton, makeStyles,
 } from '@material-ui/core';
+import MenuIcon from '@material-ui/icons/Menu';
+import appTheme from '../theme';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -16,7 +18,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const NavBar: React.SFC = function App() {
-  const classes = useStyles(useStyles);
+  const classes = useStyles(appTheme);
 
   return (
     <div className={classes.root}>
@@ -30,7 +32,9 @@ const NavBar: React.SFC = function App() {
             className={classes.menuButton}
             color="inherit"
             aria-label="menu"
-          />
+          >
+            <MenuIcon />
+          </IconButton>
           <Typography
             variant="h6"
             className={classes.title}

--- a/autoscheduler/frontend/src/components/NavBar.tsx
+++ b/autoscheduler/frontend/src/components/NavBar.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import {
-  AppBar, Toolbar, Typography, Button, IconButton, makeStyles,
+  AppBar, Toolbar, Typography, Button, makeStyles,
 } from '@material-ui/core';
-import MenuIcon from '@material-ui/icons/Menu';
 import appTheme from '../theme';
 
 const useStyles = makeStyles((theme) => ({
@@ -27,14 +26,6 @@ const NavBar: React.SFC = function App() {
         color="primary"
       >
         <Toolbar>
-          <IconButton
-            edge="start"
-            className={classes.menuButton}
-            color="inherit"
-            aria-label="menu"
-          >
-            <MenuIcon />
-          </IconButton>
           <Typography
             variant="h6"
             className={classes.title}

--- a/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
+++ b/autoscheduler/frontend/src/tests/SelectTerm.test.tsx
@@ -1,0 +1,27 @@
+import { render, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import SelectTerm from '../components/LandingPage/SelectTerm';
+
+test('Menu is closed initially', () => {
+  render(<SelectTerm />);
+
+  expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
+});
+
+test('Menu opens after button is clicked', () => {
+  const { getByText } = render(<SelectTerm />);
+  const button = getByText('Select Term');
+  fireEvent.click(button);
+
+  expect(document.getElementsByClassName('MuiPopover-root')[0]).not.toHaveAttribute('aria-hidden');
+});
+
+test('Menu closes after item is selected', () => {
+  const { getByText } = render(<SelectTerm />);
+  const button = getByText('Select Term');
+  fireEvent.click(button);
+  const testSemester = getByText('Semester 1');
+  fireEvent.click(testSemester);
+
+  expect(document.getElementsByClassName('MuiPopover-root')[0]).toHaveAttribute('aria-hidden');
+});


### PR DESCRIPTION
I've fixed various mistakes in the landing page:

- eliminated an error due to Material-UI only accepting 'top' as the anchorOrigin.vertical prop
- eliminated an error due to having `Typography` inside of `Box`
- menu icon is now showing
- `useStyle` now refers to the app theme, as it is supposed to

I would like @f4alt to review these changes for understanding before merging them into the main feature branch for `frontend-welcomepage`