### PR TITLE
Reset migrations before creating them

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,9 @@
 echo "Creating empty postgres-info.json file"
 echo "{ \"user\": \"a\", \"password\": \"a\" }" > /app/autoscheduler/config/postgres-info.json
 
+echo "Resetting migrations"
+python3 manage.py makemigrations --settings=autoscheduler.settings.docker --empty scraper
+
 echo "Creating migrations"
 python3 manage.py makemigrations --settings=autoscheduler.settings.docker scraper
 


### PR DESCRIPTION
Running docker with GitHub actions doesn't clear the database, meaning that if some migrations are already applied, our backend CI can fail because the table is incorrect. This fixes the problem by first running `makemigrations --empty scraper`, meaning migrations are now created from scratch as they should.

Check out [this pull request on my fork](https://github.com/ryan-conn/Automatic-Aggie-Scheduler/pull/1) for verification that the fix works, it uses Carlos' course scraping branch as a base (where our CI failed) and applies this change over it