### PR TITLE
Fix schedule background

### DIFF
--- a/autoscheduler/frontend/src/components/Schedule/Schedule.css
+++ b/autoscheduler/frontend/src/components/Schedule/Schedule.css
@@ -36,14 +36,15 @@
 .hour-label {
     flex-grow: 0;
     width: calc(v-time-label-margin - 4px);
-    align-self: flex-start;
+    align-self: stretch;
     text-align: right;
     padding-right: 4px;
+    background-color: #c2c2c2;
 }
 
 .hour-marker {
     flex-grow: 1;
-    border-bottom: 1px solid lightgray;
+    border-bottom: 1px solid darkgray;
     height: 0;
     align-self: stretch;
     position: relative;
@@ -73,6 +74,8 @@
     flex-grow: 1;
     display: flex;
     flex-direction: column;
+    z-index: -1;
+    background-color: white;
 }
 
 .calendar-day {


### PR DESCRIPTION
Fixes the transparent background of the schedule component. The only problem I will note is that the time bars now look bad on Google Chrome but fine on Firefox for some reason.

Google Chrome:
<img width="960" alt="2020-01-15" src="https://user-images.githubusercontent.com/10082177/72482817-98821100-37c4-11ea-982e-f23bc6ce1db6.png">

Firefox:
<img width="960" alt="2020-01-15 (1)" src="https://user-images.githubusercontent.com/10082177/72482826-9e77f200-37c4-11ea-9236-4434dda92abe.png">

Closes #117 