### PR TITLE
API Testing

### DIFF
--- a/autoscheduler/autoscheduler/settings/base.py
+++ b/autoscheduler/autoscheduler/settings/base.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
 
     'frontend',
     'scraper',

--- a/autoscheduler/autoscheduler/urls.py
+++ b/autoscheduler/autoscheduler/urls.py
@@ -18,5 +18,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('scraper.urls')),
     path('', include('frontend.urls')),
 ]

--- a/autoscheduler/scraper/models/course.py
+++ b/autoscheduler/scraper/models/course.py
@@ -12,14 +12,7 @@ class Course(models.Model):
     dept = models.CharField(max_length=4, db_index=True) # CSCE
     course_num = models.CharField(max_length=5, db_index=True) # i.e. 314
     title = models.CharField(max_length=100) # Course title, i.e. "Programming Languages"
-    description = models.TextField(blank=True)
-
-    prerequisites = models.TextField(blank=True)
-    corequisites = models.TextField(blank=True)
-
-    cd = models.BooleanField() # states whether course is a cd credit
-    icd = models.BooleanField() # states whether course is an icd credit
-    core_curriculum = models.CharField(max_length=32, blank=True) # ex 'Creative Arts'
+    term = models.CharField(max_length=6)
 
     credit_hours = models.FloatField(null=True) # Number of credit hours the course
 

--- a/autoscheduler/scraper/models/instructor.py
+++ b/autoscheduler/scraper/models/instructor.py
@@ -2,9 +2,8 @@ from django.db import models
 
 class Instructor(models.Model):
     """ Model that represents a professor, who may teach many courses """
-    id = models.IntegerField(primary_key=True)
+    id = models.CharField(max_length=100, primary_key=True)
     email_address = models.CharField(max_length=48, null=True)
-    name = models.CharField(max_length=64)
 
     class Meta:
         db_table = "instructors"

--- a/autoscheduler/scraper/models/section.py
+++ b/autoscheduler/scraper/models/section.py
@@ -10,6 +10,7 @@ class Section(models.Model):
     id = models.BigIntegerField(primary_key=True) # id is primary key in scraped data
     subject = models.CharField(max_length=4, db_index=True)
     course_num = models.IntegerField(db_index=True)
+    crn = models.IntegerField(db_index=True, default=0)
     section_num = models.IntegerField(db_index=True)
     term_code = models.IntegerField(db_index=True)
 
@@ -32,7 +33,6 @@ class Meeting(models.Model):
         Each section has one or more meetings.
     """
     id = models.BigIntegerField(primary_key=True) # id is primary key in scraped data
-    crn = models.IntegerField(db_index=True)
 
     building = models.CharField(max_length=4, null=True)
     meeting_days = ArrayField(models.BooleanField(), size=7)

--- a/autoscheduler/scraper/models/section.py
+++ b/autoscheduler/scraper/models/section.py
@@ -16,9 +16,13 @@ class Section(models.Model):
     min_credits = models.IntegerField() # Will never be null
     max_credits = models.IntegerField(null=True) # Will be null in most cases
 
+    honors_only = models.BooleanField(null=True)
+    web_only = models.BooleanField(null=True)
+
     max_enrollment = models.IntegerField()
     current_enrollment = models.IntegerField()
-    instructor = models.ForeignKey('Instructor', on_delete=models.CASCADE)
+    instructor = models.ForeignKey('Instructor', on_delete=models.CASCADE, null=True)
+    instructor_gpa = models.FloatField(null=True)
 
     class Meta:
         db_table = "sections"

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -11,19 +11,23 @@ class CourseSerializer(serializers.ModelSerializer):
 class SectionSerializer(serializers.ModelSerializer):
     """ Serializes a section """
     instructor_name = serializers.SerializerMethodField()
-    meeting_times = serializers.SerializerMethodField()
+    meetings = serializers.SerializerMethodField()
 
     class Meta:
         model = Section
-        fields = ['instructor_gpa', 'instructor_name', 'honors_only', 'meeting_times',
+        fields = ['crn', 'instructor_gpa', 'instructor_name', 'honors_only', 'meetings',
                   'section_num', 'web_only']
 
     def get_instructor_name(self, obj):
         """ Get the name (id) of this section's instructor """
         return obj.instructor.id
 
-    def get_meeting_times(self, obj):
-        """ Get this section's meetings and return an array of their start/end times """
-        section_id = obj.id
-        meetings = Meeting.objects.filter(section__id=section_id)
-        return [[meeting.start_time, meeting.end_time] for meeting in meetings]
+    def get_meetings(self, obj):
+        """ Gets meeting information for this section """
+        meetings = Meeting.objects.filter(section__id=obj.id)
+        return {str(meeting.id): {
+            'days': meeting.meeting_days,
+            'start_time': meeting.start_time,
+            'end_time': meeting.end_time,
+            'type': meeting.meeting_type,
+        } for meeting in meetings}

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -1,0 +1,23 @@
+from rest_framework import serializers
+from .models.course import Course
+from .models.section import Section, Meeting
+
+class CourseSerializer(serializers.ModelSerializer):
+    """ Serializes a course """
+    class Meta:
+        model = Course
+        fields = ['title', 'credit_hours']
+
+class SectionSerializer(serializers.ModelSerializer):
+    """ Serializes a section """
+    meeting_times = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Section
+        fields = ['instructor_gpa', 'honors_only', 'web_only', 'meeting_times']
+
+    def get_meeting_times(self, obj):
+        """ Get this section's meetings and return an array of their start/end times """
+        section_id = obj.id
+        meetings = Meeting.objects.filter(section__id=section_id)
+        return [[meeting.start_time, meeting.end_time] for meeting in meetings]

--- a/autoscheduler/scraper/serializers.py
+++ b/autoscheduler/scraper/serializers.py
@@ -10,11 +10,17 @@ class CourseSerializer(serializers.ModelSerializer):
 
 class SectionSerializer(serializers.ModelSerializer):
     """ Serializes a section """
+    instructor_name = serializers.SerializerMethodField()
     meeting_times = serializers.SerializerMethodField()
 
     class Meta:
         model = Section
-        fields = ['instructor_gpa', 'honors_only', 'web_only', 'meeting_times']
+        fields = ['instructor_gpa', 'instructor_name', 'honors_only', 'meeting_times',
+                  'section_num', 'web_only']
+
+    def get_instructor_name(self, obj):
+        """ Get the name (id) of this section's instructor """
+        return obj.instructor.id
 
     def get_meeting_times(self, obj):
         """ Get this section's meetings and return an array of their start/end times """

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -35,7 +35,7 @@ class APITests(APITestCase):
             Section(id="000002", subject="CSCE", course_num="310", section_num="502",
                     term_code="201931", min_credits="3", honors_only=False,
                     web_only=False, max_enrollment=50, current_enrollment=40,
-                    instructor=test_instructors[1]),
+                    instructor=test_instructors[1], instructor_gpa=3.2),
         ]
         self.meetings = [
             Meeting(id="0000010", crn="12345", meeting_days=[True] * 7,

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -28,28 +28,25 @@ class APITests(APITestCase):
         for instructor in test_instructors:
             instructor.save()
         self.sections = [
-            Section(id="000001", subject="CSCE", course_num="310", section_num="501",
-                    term_code="201931", min_credits="3", honors_only=False,
-                    web_only=False, max_enrollment=50, current_enrollment=40,
-                    instructor=test_instructors[0]),
-            Section(id="000002", subject="CSCE", course_num="310", section_num="502",
-                    term_code="201931", min_credits="3", honors_only=False,
-                    web_only=False, max_enrollment=50, current_enrollment=40,
-                    instructor=test_instructors[1], instructor_gpa=3.2),
+            Section(crn=12345, id="000001", subject="CSCE", course_num="310",
+                    section_num="501", term_code="201931", min_credits="3",
+                    honors_only=False, web_only=False, max_enrollment=50,
+                    current_enrollment=40, instructor=test_instructors[0]),
+            Section(crn=12346, id="000002", subject="CSCE", course_num="310",
+                    section_num="502", term_code="201931", min_credits="3",
+                    honors_only=False, web_only=False, max_enrollment=50,
+                    current_enrollment=40, instructor=test_instructors[1],
+                    instructor_gpa=3.2),
         ]
         self.meetings = [
-            Meeting(id="0000010", crn="12345", meeting_days=[True] * 7,
-                    start_time=time(11, 30), end_time=time(12, 20), meeting_type="LEC",
-                    section=self.sections[0]),
-            Meeting(id="0000011", crn="12345", meeting_days=[True] * 7,
-                    start_time=time(9, 10), end_time=time(10), meeting_type="LEC",
-                    section=self.sections[0]),
-            Meeting(id="0000020", crn="12346", meeting_days=[True] * 7,
-                    start_time=time(11, 30), end_time=time(12, 20), meeting_type="LEC",
-                    section=self.sections[1]),
-            Meeting(id="0000021", crn="12346", meeting_days=[True] * 7,
-                    start_time=time(9, 10), end_time=time(10), meeting_type="LEC",
-                    section=self.sections[1]),
+            Meeting(id="0000010", meeting_days=[True] * 7, start_time=time(11, 30),
+                    end_time=time(12, 20), meeting_type="LEC", section=self.sections[0]),
+            Meeting(id="0000011", meeting_days=[True] * 7, start_time=time(9, 10),
+                    end_time=time(10), meeting_type="LEC", section=self.sections[0]),
+            Meeting(id="0000020", meeting_days=[True] * 7, start_time=time(11, 30),
+                    end_time=time(12, 20), meeting_type="LEC", section=self.sections[1]),
+            Meeting(id="0000021", meeting_days=[False] * 7, start_time=time(9, 10),
+                    end_time=time(10), meeting_type="LAB", section=self.sections[1]),
         ]
         for course in self.courses:
             course.save()
@@ -133,11 +130,26 @@ class APITests(APITestCase):
         first_end = time(12, 20)
         second_start = time(9, 10)
         second_end = time(10)
+        meeting_days = [True] * 7
         expected = {
+            'crn': 12345,
             'instructor_gpa': None,
             'instructor_name': 'Akash Tyagi',
             'honors_only': False,
-            'meeting_times': [[first_start, first_end], [second_start, second_end]],
+            'meetings': {
+                '10': {
+                    'days': meeting_days,
+                    'start_time': first_start,
+                    'end_time': first_end,
+                    'type': 'LEC',
+                },
+                '11': {
+                    'days': meeting_days,
+                    'start_time': second_start,
+                    'end_time': second_end,
+                    'type': 'LEC',
+                },
+            },
             'section_num': 501,
             'web_only': False,
         }
@@ -157,20 +169,50 @@ class APITests(APITestCase):
         first_end = time(12, 20)
         second_start = time(9, 10)
         second_end = time(10)
+        meeting_days_true = [True] * 7
+        meeting_days_false = [False] * 7
         expected = {
-            '000001': {
+            '1': {
+                'crn': 12345,
                 'instructor_gpa': None,
                 'instructor_name': 'Akash Tyagi',
                 'honors_only': False,
-                'meeting_times': [[first_start, first_end], [second_start, second_end]],
+                'meetings': {
+                    '10': {
+                        'days': meeting_days_true,
+                        'start_time': first_start,
+                        'end_time': first_end,
+                        'type': 'LEC',
+                    },
+                    '11': {
+                        'days': meeting_days_true,
+                        'start_time': second_start,
+                        'end_time': second_end,
+                        'type': 'LEC',
+                    },
+                },
                 'section_num': 501,
                 'web_only': False,
             },
-            '000002': {
-                'instructor_gpa': 3.2,
+            '2': {
+                'crn': 12346,
+                'instructor_gpa': None,
                 'instructor_name': 'John Moore',
-                'honors_only': True,
-                'meeting_times': [[first_start, first_end], [second_start, second_end]],
+                'honors_only': False,
+                'meetings': {
+                    '20': {
+                        'days': meeting_days_true,
+                        'start_time': first_start,
+                        'end_time': first_end,
+                        'type': 'LEC',
+                    },
+                    '21': {
+                        'days': meeting_days_false,
+                        'start_time': second_start,
+                        'end_time': second_end,
+                        'type': 'LAB',
+                    },
+                },
                 'section_num': 502,
                 'web_only': False,
             },

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -1,0 +1,172 @@
+from datetime import time
+from rest_framework.test import APITestCase, APIClient
+from scraper.models.course import Course
+from scraper.models.instructor import Instructor
+from scraper.models.section import Section, Meeting
+from scraper.serializers import CourseSerializer, SectionSerializer
+
+class APITests(APITestCase):
+    """ Tests API functionality """
+    def setUp(self):
+        self.client = APIClient()
+        self.courses = [
+            Course(id="123123", dept="CSCE", course_num="181",
+                   title="Introduction to Computing", term="201931", credit_hours=3),
+            Course(id="123124", dept="CSCE", course_num="315",
+                   title="Programming Studio", term="201931", credit_hours=3),
+            Course(id="123125", dept="COMM", course_num="203",
+                   title="Public Speaking", term="201831", credit_hours=3),
+            Course(id="123126", dept="COMM", course_num="203",
+                   title="Public Speaking", term="201931", credit_hours=3),
+            Course(id="123127", dept="LAW", course_num="7500S",
+                   title="Sports Law", term="202031", credit_hours=None),
+        ]
+        test_instructor = Instructor(id="Akash Tyagi")
+        test_instructor.save()
+        self.sections = [
+            Section(id="000001", subject="CSCE", course_num="310", section_num="501",
+                    term_code="201931", min_credits="3", honors_only=False,
+                    web_only=False, max_enrollment=50, current_enrollment=40,
+                    instructor=test_instructor),
+        ]
+        self.meetings = [
+            Meeting(id="0000010", crn="12345", meeting_days=[True] * 7,
+            start_time=time(11, 30), end_time=time(12, 20), meeting_type="LEC",
+            section=self.sections[0]),
+            Meeting(id="0000011", crn="12345", meeting_days=[True] * 7,
+            start_time=time(9, 10), end_time=time(10), meeting_type="LEC",
+            section=self.sections[0]),
+        ]
+        for course in self.courses:
+            course.save()
+        for section in self.sections:
+            section.save()
+        for meeting in self.meetings:
+            meeting.save()
+
+    def test_api_terms_displays_all_terms(self):
+        """ Tests that /api/terms returns ordered list of all terms in database """
+        # Arrange
+        expected = {
+            "201831": "Fall 2018 - College Station",
+            "201931": "Fall 2019 - College Station",
+            "202031": "Fall 2020 - College Station",
+        }
+
+        # Act
+        response = self.client.get("/api/terms")
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected, response)
+
+    def test_api_course_serializer_gives_expected_output(self):
+        """ Tests that the course serializer yields the correct data """
+        # Arrange
+        expected = {'title': 'Introduction to Computing', 'credit_hours': 3}
+
+        # Act
+        serializer = CourseSerializer(self.courses[0])
+
+        # Assert
+        self.assertEqual(expected, serializer.data)
+
+    def test_api_course_serializer_handles_null_credit_hours(self):
+        """ Tests that the course serializer correctly handles null credit_hours """
+        # Arrange
+        expected = {'title': 'Sports Law', 'credit_hours': None}
+
+        # Act
+        serializer = CourseSerializer(self.courses[4])
+
+        # Assert
+        self.assertEqual(expected, serializer.data)
+
+    def test_api_course_gives_valid_response_csce(self):
+        """ Tests that /api/course?dept=CSCE&course_num=181&term=201931 gives the
+            correct output
+        """
+        # Arrange
+        expected = CourseSerializer(self.courses[0])
+        data = {'dept': 'CSCE', 'course_num': '181', 'term': '201931'}
+
+        # Act
+        response = self.client.get("/api/course", data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()[0], expected.data)
+
+    def test_api_course_gives_valid_response_law(self):
+        """ Tests that /api/course?dept=LAW&course_num=7500S&term=202031 gives the
+            correct output (verifies API can handle null credit_hours)
+        """
+        # Arrange
+        expected = CourseSerializer(self.courses[4])
+        data = {'dept': 'LAW', 'course_num': '7500S', 'term': '202031'}
+
+        # Act
+        response = self.client.get("/api/course", data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()[0], expected.data)
+
+    def test_api_section_serializer_gives_expected_output(self):
+        """ Tests that the section serializer yields the correct data """
+        # Arrange
+        first_start = time(11, 30)
+        first_end = time(12, 20)
+        second_start = time(9, 10)
+        second_end = time(10)
+        expected = {
+            'instructor_gpa': None,
+            'honors_only': False,
+            'web_only': False,
+            'meeting_times': [[first_start, first_end], [second_start, second_end]]
+        }
+
+        # Act
+        serializer = SectionSerializer(self.sections[0])
+
+        # Assert
+        self.assertEqual(expected, serializer.data)
+
+    def test_api_section_gives_valid_response(self):
+        """ Tests that /api/section?id=000001&term=201931 gives the correct output """
+        # Arrange
+        expected = SectionSerializer(self.sections[0])
+        data = {'id': '000001', 'term': '201931'}
+
+        # Act
+        response = self.client.get("/api/section", data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()[0], expected.data)
+
+    def test_api_course_search_gives_correct_results_cs(self):
+        """ Tests that /api/course/search?search=CS&term=201931 gives correct output """
+        # Arrange
+        expected = {'results': ["CSCE 181", "CSCE 315"]}
+        data = {'search': 'CS', 'term': '201931'}
+
+        # Act
+        response = self.client.get("/api/course/search", data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()[0], expected)
+
+    def test_api_course_search_gives_correct_results_c(self):
+        """ Tests that /api/course/search?search=C&term=201931 gives correct output """
+        # Arrange
+        expected = {'results': ["COMM 203", "CSCE 181", "CSCE 315"]}
+        data = {'search': 'CS', 'term': '201931'}
+
+        # Act
+        response = self.client.get("/api/course/search", data=data)
+
+        # Assert
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()[0], expected)

--- a/autoscheduler/scraper/tests/api_tests.py
+++ b/autoscheduler/scraper/tests/api_tests.py
@@ -21,21 +21,35 @@ class APITests(APITestCase):
             Course(id="123127", dept="LAW", course_num="7500S",
                    title="Sports Law", term="202031", credit_hours=None),
         ]
-        test_instructor = Instructor(id="Akash Tyagi")
-        test_instructor.save()
+        test_instructors = [
+            Instructor(id="Akash Tyagi"),
+            Instructor(id="John Moore"),
+        ]
+        for instructor in test_instructors:
+            instructor.save()
         self.sections = [
             Section(id="000001", subject="CSCE", course_num="310", section_num="501",
                     term_code="201931", min_credits="3", honors_only=False,
                     web_only=False, max_enrollment=50, current_enrollment=40,
-                    instructor=test_instructor),
+                    instructor=test_instructors[0]),
+            Section(id="000002", subject="CSCE", course_num="310", section_num="502",
+                    term_code="201931", min_credits="3", honors_only=False,
+                    web_only=False, max_enrollment=50, current_enrollment=40,
+                    instructor=test_instructors[1]),
         ]
         self.meetings = [
             Meeting(id="0000010", crn="12345", meeting_days=[True] * 7,
-            start_time=time(11, 30), end_time=time(12, 20), meeting_type="LEC",
-            section=self.sections[0]),
+                    start_time=time(11, 30), end_time=time(12, 20), meeting_type="LEC",
+                    section=self.sections[0]),
             Meeting(id="0000011", crn="12345", meeting_days=[True] * 7,
-            start_time=time(9, 10), end_time=time(10), meeting_type="LEC",
-            section=self.sections[0]),
+                    start_time=time(9, 10), end_time=time(10), meeting_type="LEC",
+                    section=self.sections[0]),
+            Meeting(id="0000020", crn="12346", meeting_days=[True] * 7,
+                    start_time=time(11, 30), end_time=time(12, 20), meeting_type="LEC",
+                    section=self.sections[1]),
+            Meeting(id="0000021", crn="12346", meeting_days=[True] * 7,
+                    start_time=time(9, 10), end_time=time(10), meeting_type="LEC",
+                    section=self.sections[1]),
         ]
         for course in self.courses:
             course.save()
@@ -95,7 +109,7 @@ class APITests(APITestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()[0], expected.data)
+        self.assertEqual(response.json(), expected.data)
 
     def test_api_course_gives_valid_response_law(self):
         """ Tests that /api/course?dept=LAW&course_num=7500S&term=202031 gives the
@@ -110,7 +124,7 @@ class APITests(APITestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()[0], expected.data)
+        self.assertEqual(response.json(), expected.data)
 
     def test_api_section_serializer_gives_expected_output(self):
         """ Tests that the section serializer yields the correct data """
@@ -121,9 +135,11 @@ class APITests(APITestCase):
         second_end = time(10)
         expected = {
             'instructor_gpa': None,
+            'instructor_name': 'Akash Tyagi',
             'honors_only': False,
+            'meeting_times': [[first_start, first_end], [second_start, second_end]],
+            'section_num': 501,
             'web_only': False,
-            'meeting_times': [[first_start, first_end], [second_start, second_end]]
         }
 
         # Act
@@ -132,18 +148,41 @@ class APITests(APITestCase):
         # Assert
         self.assertEqual(expected, serializer.data)
 
-    def test_api_section_gives_valid_response(self):
-        """ Tests that /api/section?id=000001&term=201931 gives the correct output """
+    def test_api_sections_gives_valid_response(self):
+        """ Tests that /api/sections?&dept=CSCE&course_num=310term=201931 gives the
+            correct output
+        """
         # Arrange
-        expected = SectionSerializer(self.sections[0])
-        data = {'id': '000001', 'term': '201931'}
+        first_start = time(11, 30)
+        first_end = time(12, 20)
+        second_start = time(9, 10)
+        second_end = time(10)
+        expected = {
+            '000001': {
+                'instructor_gpa': None,
+                'instructor_name': 'Akash Tyagi',
+                'honors_only': False,
+                'meeting_times': [[first_start, first_end], [second_start, second_end]],
+                'section_num': 501,
+                'web_only': False,
+            },
+            '000002': {
+                'instructor_gpa': 3.2,
+                'instructor_name': 'John Moore',
+                'honors_only': True,
+                'meeting_times': [[first_start, first_end], [second_start, second_end]],
+                'section_num': 502,
+                'web_only': False,
+            },
+        }
+        data = {'dept': 'CSCE', 'course_num': 310, 'term': '201931'}
 
         # Act
-        response = self.client.get("/api/section", data=data)
+        response = self.client.get("/api/sections", data=data)
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()[0], expected.data)
+        self.assertEqual(response.json(), expected)
 
     def test_api_course_search_gives_correct_results_cs(self):
         """ Tests that /api/course/search?search=CS&term=201931 gives correct output """
@@ -156,17 +195,17 @@ class APITests(APITestCase):
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()[0], expected)
+        self.assertEqual(response.json(), expected)
 
     def test_api_course_search_gives_correct_results_c(self):
         """ Tests that /api/course/search?search=C&term=201931 gives correct output """
         # Arrange
         expected = {'results': ["COMM 203", "CSCE 181", "CSCE 315"]}
-        data = {'search': 'CS', 'term': '201931'}
+        data = {'search': 'C', 'term': '201931'}
 
         # Act
         response = self.client.get("/api/course/search", data=data)
 
         # Assert
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()[0], expected)
+        self.assertEqual(response.json(), expected)

--- a/autoscheduler/scraper/urls.py
+++ b/autoscheduler/scraper/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from scraper.views import RetrieveCourseView
+
+urlpatterns = [
+    path('course', RetrieveCourseView.as_view()),
+]

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -1,4 +1,14 @@
-# Once we start adding routes, uncomment this line
-# from django.shortcuts import render
+from rest_framework import generics
 
-# Create your views here.
+from .serializers import CourseSerializer
+from .models.course import Course
+
+class RetrieveCourseView(generics.ListAPIView):
+    """ API endpoint for viewing course information """
+    serializer_class = CourseSerializer
+
+    def get_queryset(self):
+        dept = self.request.query_params.get('dept')
+        course_num = self.request.query_params.get('course_num')
+        term = self.request.query_params.get('term')
+        return Course.objects.filter(dept=dept, course_num=course_num, term=term)

--- a/autoscheduler/scraper/views.py
+++ b/autoscheduler/scraper/views.py
@@ -1,14 +1,14 @@
 from rest_framework import generics
-
 from .serializers import CourseSerializer
 from .models.course import Course
 
-class RetrieveCourseView(generics.ListAPIView):
+class RetrieveCourseView(generics.RetrieveAPIView):
     """ API endpoint for viewing course information """
     serializer_class = CourseSerializer
 
-    def get_queryset(self):
+    def get_object(self):
+        """ Overrides default behavior of get_object() to work without a primary key """
         dept = self.request.query_params.get('dept')
         course_num = self.request.query_params.get('course_num')
         term = self.request.query_params.get('term')
-        return Course.objects.filter(dept=dept, course_num=course_num, term=term)
+        return Course.objects.get(dept=dept, course_num=course_num, term=term)


### PR DESCRIPTION
This should be a draft PR, I clicked the button when I started it but it made it a normal PR anyways 🤷


I've created a few tests for each route we'll need for the API (see #115). The most important things to look at are `scraper/urls.py` (defines which routes we need), `scraper/views.py` (defines the serializer, parameters, and queryset to use for each route), and `api_testing.py`, which has tests for all the routes. I've created a url and view for `/api/course`, which you can look at as an example for the other routes.

When creating views for the other models, the results should be formatted the same as the expected data in the test cases I created:
`/api/terms`:
```
{
    "201831": "Fall 2018 - College Station",
    "201931": "Fall 2019 - College Station",
    "202031": "Fall 2020 - College Station",
}
```
`/api/sections`:
```
'1': {
    'crn': 12345,
    'instructor_gpa': None,
    'instructor_name': 'Akash Tyagi',
    'honors_only': False,
    'meetings': {
        '10': {
            'days': meeting_days_true,
            'start_time': first_start,
            'end_time': first_end,
            'type': 'LEC',
        },
        '11': {
            'days': meeting_days_true,
            'start_time': second_start,
            'end_time': second_end,
            'type': 'LEC',
        },
    },
    'section_num': 501,
    'web_only': False,
},
'2': {
    'crn': 12346,
    'instructor_gpa': None,
    'instructor_name': 'John Moore',
    'honors_only': False,
    'meetings': {
        '20': {
            'days': meeting_days_true,
            'start_time': first_start,
            'end_time': first_end,
            'type': 'LEC',
        },
        '21': {
            'days': meeting_days_false,
            'start_time': second_start,
            'end_time': second_end,
            'type': 'LAB',
        },
    },
    'section_num': 502,
    'web_only': False,
},
```
Note that it's a little tricky to format the data like this, you'll have to override the `list(self, request, *args, **kwargs)` method for `ListAPIView` in order to return a dictionary with ids as the keys instead of the default behavior (list comprehension with serializer called on each object in the queryset)
`/api/course`:
```
{
    'title': 'Sports Law',
    'credit_hours': None,
}
```
`/api/course/search`:
```
{'results': ["CSCE 181", "CSCE 315"]}
```
Please note that not all the tests are passing now, since not all the routes have been implemented yet.